### PR TITLE
V3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 3.0.0 (17/06/2020)
+
+### Breaking changes
+ * Contracts compiler version fixed at solidity 0.6.8.
+ * `shouldSupportInterfaces` is no more exposed at module level but inside the `behaviors` object instead.
+ * Updated mocha dependency from version 7 to version 8.
+
+### New features
+ * `behaviors` and `fixtures` object are now exposed at module level.
+ * Added fixtures for wei-based BN comparison with precision tolerance.
+ * Added a `verify` and a `publish` scripts. 
+
+### Improvements
+ * `shouldSupportInterfaces` now works on `this.contract` object.
+
 ## 2.0.0 (27/05/2020)
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Solidity Project Contracts Core Library
 
-This project serves as a base dependency for Solidity-based contract projects by providing common configurations, contacts, scripts, interfaces, constants, and utilities.
+This project serves as a base dependency for Solidity-based smart contract projects by providing common dependencies, configurations, contracts, scripts, interfaces, constants, and testing utilities.
 
 
 ## Table of Contents
@@ -8,28 +8,63 @@ This project serves as a base dependency for Solidity-based contract projects by
 - [Overview](#overview)
   * [Installation](#installation)
   * [Usage](#usage)
+    - [Commands](#commands)
     - [Solidity Contracts](#solidity-contracts)
     - [Test and Migration Scripts](#test-and-migration-scripts)
 - [Configurations](#configurations)
   * [Openzeppelin Test Environment](#openzeppelin-test-environment)
   * [Truffle Config](#truffle-config)
   * [Truffle Security](#truffle-security)
-- [Scripts](#scripts)
 
 
 ## Overview
-
 
 ### Installation
 
 Install as a module dependency in your host NodeJS project:
 
 ```bash
-$ npm install --save @animoca/ethereum-contracts-core_library
+npm install --save-dev @animoca/ethereum-contracts-core_library
 ```
 
 
 ### Usage
+
+#### Commands
+
+```bash
+npm run compile
+```
+Compiles all the contracts in the `contracts/` directory.
+
+```bash
+npm run test [files]
+```
+Runs all the tests. If `files` are specified, runs only these test files.
+
+```bash
+npm run coverage
+```
+Runs the test coverage.
+
+```bash
+npm run migrate --network <network>
+```
+Runs the migrations on the specified `network`.
+The network `ganache` can be used for testing.
+
+```bash
+npm run verify
+```
+Runs a static analysis on the specified `contracts` through MythX API.
+Note: an API key is required to run this command.
+
+```bash
+npm run publish
+```
+Verifies and publishes the contract code through Etherscan API.
+Note: an API key is required to run this command, refer to `truffle-config.js` for a code snippet.
+
 
 #### Solidity Contracts
 
@@ -45,7 +80,7 @@ import "@animoca/ethereum-contracts-core_library/contracts/{{Contract Group}}/{{
 Require the NodeJS module dependency in your test and migration scripts as needed:
 
 ```javascript
-const { constants, interfaces, shouldSupportInterfaces } = require('@animoca/ethereum-contracts-core_library');
+const { constants, interfaces, behaviors, fixtures } = require('@animoca/ethereum-contracts-core_library');
 ```
 
 
@@ -64,13 +99,3 @@ The Truffle configuration file defines the configuration properties used by the 
 #### Truffle Security
 
 The Truffle Security configuration file defines the configuration properties used by the [MythX Security Analysis Truffle plugin](https://www.npmjs.com/package/truffle-security) to provide static analysis for security vulnerabilities during Truffle's contract compilation process. Once this core library project is included as a dependency of your host NodeJS project, the configuration file can be found in **node_modules/@animoca/ethereum-contracts-core_library/truffle-security.js**
-
-
-### Scripts
-
-This core library project provides some helpful scripts for the development of your Solidity-based project. These can be found in **node_modules/@animoca/ethereum-contracts-core_library/scripts/**.
-
-+ **oz-compile.sh** - Compiles the Solidity contracts using the Openzeppelin CLI.
-+ **oz-test.sh** - Compiles and runs the Mocha + Chai based test suites using Openzeppelin's testing framework.
-+ **migrate.sh** - Executes the Truffle migration scripts to deploy the contracts on Truffle's Ganache local blockchain.
-+ **coverage.sh** - Executes Truffle coverage tests on the Solidity contracts.

--- a/contracts/access/MinterRole.sol
+++ b/contracts/access/MinterRole.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.8;
 
 import "@openzeppelin/contracts/access/AccessControl.sol";
 

--- a/contracts/access/PauserRole.sol
+++ b/contracts/access/PauserRole.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.8;
 
 import "@openzeppelin/contracts/access/AccessControl.sol";
 

--- a/contracts/access/WhitelistedOperators.sol
+++ b/contracts/access/WhitelistedOperators.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.8;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/contracts/algo/EnumMap.sol
+++ b/contracts/algo/EnumMap.sol
@@ -27,7 +27,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.8;
 
 /**
  * @dev Library for managing an enumerable variant of Solidity's

--- a/contracts/algo/EnumSet.sol
+++ b/contracts/algo/EnumSet.sol
@@ -27,7 +27,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.8;
 
 /**
  * @dev Library for managing

--- a/contracts/mocks/algo/EnumMapMock.sol
+++ b/contracts/mocks/algo/EnumMapMock.sol
@@ -27,7 +27,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.8;
 
 import "../../algo/EnumMap.sol";
 

--- a/contracts/mocks/algo/EnumSetMock.sol
+++ b/contracts/mocks/algo/EnumSetMock.sol
@@ -27,7 +27,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.8;
 
 import "../../algo/EnumSet.sol";
 

--- a/contracts/mocks/utils/types/Bytes32ToStringMock.sol
+++ b/contracts/mocks/utils/types/Bytes32ToStringMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.8;
 
 import "../../../utils/types/Bytes32ToBase32String.sol";
 

--- a/contracts/mocks/utils/types/UInt256BitsMock.sol
+++ b/contracts/mocks/utils/types/UInt256BitsMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.8;
 
 import "../../../utils/types/UInt256Extract.sol";
 import "../../../utils/types/UInt256Inject.sol";

--- a/contracts/mocks/utils/types/UInt256ToStringMock.sol
+++ b/contracts/mocks/utils/types/UInt256ToStringMock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.8;
 
 import "../../../utils/types/UInt256ToDecimalString.sol";
 import "../../../utils/types/UInt256ToHexString.sol";

--- a/contracts/payment/PayoutWallet.sol
+++ b/contracts/payment/PayoutWallet.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.8;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 

--- a/contracts/utils/types/Bytes32ToBase32String.sol
+++ b/contracts/utils/types/Bytes32ToBase32String.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.8;
 
 library Bytes32ToBase32String {
 

--- a/contracts/utils/types/UInt256Extract.sol
+++ b/contracts/utils/types/UInt256Extract.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.8;
 
 library UInt256Extract {
 

--- a/contracts/utils/types/UInt256Inject.sol
+++ b/contracts/utils/types/UInt256Inject.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.8;
 
 library UInt256Inject {
 

--- a/contracts/utils/types/UInt256ToDecimalString.sol
+++ b/contracts/utils/types/UInt256ToDecimalString.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.8;
 
 library UInt256ToDecimalString {
 

--- a/contracts/utils/types/UInt256ToHexString.sol
+++ b/contracts/utils/types/UInt256ToHexString.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.6.8;
+pragma solidity 0.6.8;
 
 library UInt256ToHexString {
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@animoca/ethereum-contracts-core_library",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -596,9 +596,9 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.0.1.tgz",
-      "integrity": "sha512-uSrD7hZ0ViuHGqHZbeHawZBi/uy7aBiNramXAt2dFFuSuoU4u9insS3V3zdVfOnYSPreUo636xSOuQIFN4//HA=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-3.0.2.tgz",
+      "integrity": "sha512-eK9F3jEbjQeRYLiqrHUrXCZBxE+7L4Ve5scYInsLezuasoFkrrEFlnDWD8gbN+6e5NgdgJP9fTWxjxWmaHh7dA=="
     },
     "@openzeppelin/fuzzy-solidity-import-parser": {
       "version": "0.1.2",
@@ -675,12 +675,12 @@
       }
     },
     "@openzeppelin/test-helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/test-helpers/-/test-helpers-0.5.5.tgz",
-      "integrity": "sha512-jTSCQojQ0Q7FBMN3Me7o0OIVuRnfHRR9TcE+ZlfbSfdqrHkFLwSfeDHSNWtQGlF1xPQR5r3iRI0ccsCrN+JblA==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/test-helpers/-/test-helpers-0.5.6.tgz",
+      "integrity": "sha512-8U4sR4ed4cFmc6UKj7akUxZzQJKU9P3p/3RbF+urQuRLLhBaB8zSya1m9VB7/anYEZnBmTDk8LuVgAmYaCPs9A==",
       "requires": {
         "@openzeppelin/contract-loader": "^0.4.0",
-        "@truffle/contract": "^4.0.35",
+        "@truffle/contract": "^4.0.35 <4.2.2",
         "ansi-colors": "^3.2.3",
         "chai": "^4.2.0",
         "chai-bn": "^0.2.1",
@@ -701,10 +701,98 @@
             "try-require": "^1.2.1"
           }
         },
+        "@truffle/blockchain-utils": {
+          "version": "0.0.18",
+          "resolved": "https://registry.npmjs.org/@truffle/blockchain-utils/-/blockchain-utils-0.0.18.tgz",
+          "integrity": "sha512-XnRu5p1QO9krJizOeBY5WfzPDvEOmCnOT5u6qF8uN3Kkq9vcH3ZqW4XTuzz9ERZNpZfWb3UJx4PUosgeHLs5vw==",
+          "requires": {
+            "source-map-support": "^0.5.16"
+          }
+        },
+        "@truffle/contract": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.2.1.tgz",
+          "integrity": "sha512-af1rUyU/W75GYHt/i7r+NwHozwaCma7V/q/+SRZ3Cw2MFaGOQ0dA/ZGhH8P1F0fmDiUe1DBEIbKxXWai0PWFYg==",
+          "requires": {
+            "@truffle/blockchain-utils": "^0.0.18",
+            "@truffle/contract-schema": "^3.1.0",
+            "@truffle/error": "^0.0.8",
+            "@truffle/interface-adapter": "^0.4.6",
+            "bignumber.js": "^7.2.1",
+            "ethereum-ens": "^0.8.0",
+            "ethers": "^4.0.0-beta.1",
+            "exorcist": "^1.0.1",
+            "source-map-support": "^0.5.16",
+            "web3": "1.2.1",
+            "web3-core-promievent": "1.2.1",
+            "web3-eth-abi": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3/-/web3-1.2.1.tgz",
+              "integrity": "sha512-nNMzeCK0agb5i/oTWNdQ1aGtwYfXzHottFP2Dz0oGIzavPMGSKyVlr8ibVb1yK5sJBjrWVnTdGaOC2zKDFuFRw==",
+              "requires": {
+                "web3-bzz": "1.2.1",
+                "web3-core": "1.2.1",
+                "web3-eth": "1.2.1",
+                "web3-eth-personal": "1.2.1",
+                "web3-net": "1.2.1",
+                "web3-shh": "1.2.1",
+                "web3-utils": "1.2.1"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "@truffle/error": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.8.tgz",
+          "integrity": "sha512-x55rtRuNfRO1azmZ30iR0pf0OJ6flQqbax1hJz+Avk1K5fdmOv5cr22s9qFnwTWnS6Bw0jvJEoR0ITsM7cPKtQ=="
+        },
+        "@types/node": {
+          "version": "10.17.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+          "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
+        },
         "ansi-colors": {
           "version": "3.2.4",
           "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
           "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
+        },
+        "bignumber.js": {
+          "version": "7.2.1",
+          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+          "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+        },
+        "bn.js": {
+          "version": "4.11.8",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+        },
+        "eth-lib": {
+          "version": "0.2.7",
+          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+          "requires": {
+            "bn.js": "^4.11.6",
+            "elliptic": "^6.4.0",
+            "xhr-request-promise": "^0.1.2"
+          }
         },
         "find-up": {
           "version": "4.1.0",
@@ -758,6 +846,458 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "scrypt-js": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
+          "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q="
+        },
+        "underscore": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
+        },
+        "uuid": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+        },
+        "web3-bzz": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.1.tgz",
+          "integrity": "sha512-LdOO44TuYbGIPfL4ilkuS89GQovxUpmLz6C1UC7VYVVRILeZS740FVB3j9V4P4FHUk1RenaDfKhcntqgVCHtjw==",
+          "requires": {
+            "got": "9.6.0",
+            "swarm-js": "0.1.39",
+            "underscore": "1.9.1"
+          }
+        },
+        "web3-core": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.1.tgz",
+          "integrity": "sha512-5ODwIqgl8oIg/0+Ai4jsLxkKFWJYE0uLuE1yUKHNVCL4zL6n3rFjRMpKPokd6id6nJCNgeA64KdWQ4XfpnjdMg==",
+          "requires": {
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-core-requestmanager": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-core-helpers": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.1.tgz",
+          "integrity": "sha512-Gx3sTEajD5r96bJgfuW377PZVFmXIH4TdqDhgGwd2lZQCcMi+DA4TgxJNJGxn0R3aUVzyyE76j4LBrh412mXrw==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-eth-iban": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-core-method": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.1.tgz",
+          "integrity": "sha512-Ghg2WS23qi6Xj8Od3VCzaImLHseEA7/usvnOItluiIc5cKs00WYWsNy2YRStzU9a2+z8lwQywPYp0nTzR/QXdQ==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-promievent": "1.2.1",
+            "web3-core-subscriptions": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-core-promievent": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.1.tgz",
+          "integrity": "sha512-IVUqgpIKoeOYblwpex4Hye6npM0aMR+kU49VP06secPeN0rHMyhGF0ZGveWBrGvf8WDPI7jhqPBFIC6Jf3Q3zw==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "eventemitter3": "3.1.2"
+          }
+        },
+        "web3-core-requestmanager": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.1.tgz",
+          "integrity": "sha512-xfknTC69RfYmLKC+83Jz73IC3/sS2ZLhGtX33D4Q5nQ8yc39ElyAolxr9sJQS8kihOcM6u4J+8gyGMqsLcpIBg==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-providers-http": "1.2.1",
+            "web3-providers-ipc": "1.2.1",
+            "web3-providers-ws": "1.2.1"
+          }
+        },
+        "web3-core-subscriptions": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.1.tgz",
+          "integrity": "sha512-nmOwe3NsB8V8UFsY1r+sW6KjdOS68h8nuh7NzlWxBQT/19QSUGiERRTaZXWu5BYvo1EoZRMxCKyCQpSSXLc08g==",
+          "requires": {
+            "eventemitter3": "3.1.2",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1"
+          }
+        },
+        "web3-eth": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.1.tgz",
+          "integrity": "sha512-/2xly4Yry5FW1i+uygPjhfvgUP/MS/Dk+PDqmzp5M88tS86A+j8BzKc23GrlA8sgGs0645cpZK/999LpEF5UdA==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-core-subscriptions": "1.2.1",
+            "web3-eth-abi": "1.2.1",
+            "web3-eth-accounts": "1.2.1",
+            "web3-eth-contract": "1.2.1",
+            "web3-eth-ens": "1.2.1",
+            "web3-eth-iban": "1.2.1",
+            "web3-eth-personal": "1.2.1",
+            "web3-net": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-eth-abi": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.1.tgz",
+          "integrity": "sha512-jI/KhU2a/DQPZXHjo2GW0myEljzfiKOn+h1qxK1+Y9OQfTcBMxrQJyH5AP89O6l6NZ1QvNdq99ThAxBFoy5L+g==",
+          "requires": {
+            "ethers": "4.0.0-beta.3",
+            "underscore": "1.9.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "elliptic": {
+              "version": "6.3.3",
+              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
+              "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
+              "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "inherits": "^2.0.1"
+              }
+            },
+            "ethers": {
+              "version": "4.0.0-beta.3",
+              "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
+              "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
+              "requires": {
+                "@types/node": "^10.3.2",
+                "aes-js": "3.0.0",
+                "bn.js": "^4.4.0",
+                "elliptic": "6.3.3",
+                "hash.js": "1.1.3",
+                "js-sha3": "0.5.7",
+                "scrypt-js": "2.0.3",
+                "setimmediate": "1.0.4",
+                "uuid": "2.0.1",
+                "xmlhttprequest": "1.8.0"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-eth-accounts": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.1.tgz",
+          "integrity": "sha512-26I4qq42STQ8IeKUyur3MdQ1NzrzCqPsmzqpux0j6X/XBD7EjZ+Cs0lhGNkSKH5dI3V8CJasnQ5T1mNKeWB7nQ==",
+          "requires": {
+            "any-promise": "1.3.0",
+            "crypto-browserify": "3.12.0",
+            "eth-lib": "0.2.7",
+            "scryptsy": "2.1.0",
+            "semver": "6.2.0",
+            "underscore": "1.9.1",
+            "uuid": "3.3.2",
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.2.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+              "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A=="
+            },
+            "uuid": {
+              "version": "3.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+              "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            },
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-eth-contract": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.1.tgz",
+          "integrity": "sha512-kYFESbQ3boC9bl2rYVghj7O8UKMiuKaiMkxvRH5cEDHil8V7MGEGZNH0slSdoyeftZVlaWSMqkRP/chfnKND0g==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-core-promievent": "1.2.1",
+            "web3-core-subscriptions": "1.2.1",
+            "web3-eth-abi": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-eth-ens": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.1.tgz",
+          "integrity": "sha512-lhP1kFhqZr2nnbu3CGIFFrAnNxk2veXpOXBY48Tub37RtobDyHijHgrj+xTh+mFiPokyrapVjpFsbGa+Xzye4Q==",
+          "requires": {
+            "eth-ens-namehash": "2.0.8",
+            "underscore": "1.9.1",
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-promievent": "1.2.1",
+            "web3-eth-abi": "1.2.1",
+            "web3-eth-contract": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-eth-iban": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.1.tgz",
+          "integrity": "sha512-9gkr4QPl1jCU+wkgmZ8EwODVO3ovVj6d6JKMos52ggdT2YCmlfvFVF6wlGLwi0VvNa/p+0BjJzaqxnnG/JewjQ==",
+          "requires": {
+            "bn.js": "4.11.8",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-eth-personal": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.1.tgz",
+          "integrity": "sha512-RNDVSiaSoY4aIp8+Hc7z+X72H7lMb3fmAChuSBADoEc7DsJrY/d0R5qQDK9g9t2BO8oxgLrLNyBP/9ub2Hc6Bg==",
+          "requires": {
+            "web3-core": "1.2.1",
+            "web3-core-helpers": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-net": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-net": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.1.tgz",
+          "integrity": "sha512-Yt1Bs7WgnLESPe0rri/ZoPWzSy55ovioaP35w1KZydrNtQ5Yq4WcrAdhBzcOW7vAkIwrsLQsvA+hrOCy7mNauw==",
+          "requires": {
+            "web3-core": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-utils": "1.2.1"
+          },
+          "dependencies": {
+            "web3-utils": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+              "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randomhex": "0.1.5",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
+          }
+        },
+        "web3-providers-http": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.1.tgz",
+          "integrity": "sha512-BDtVUVolT9b3CAzeGVA/np1hhn7RPUZ6YYGB/sYky+GjeO311Yoq8SRDUSezU92x8yImSC2B+SMReGhd1zL+bQ==",
+          "requires": {
+            "web3-core-helpers": "1.2.1",
+            "xhr2-cookies": "1.1.0"
+          }
+        },
+        "web3-providers-ipc": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.1.tgz",
+          "integrity": "sha512-oPEuOCwxVx8L4CPD0TUdnlOUZwGBSRKScCz/Ws2YHdr9Ium+whm+0NLmOZjkjQp5wovQbyBzNa6zJz1noFRvFA==",
+          "requires": {
+            "oboe": "2.1.4",
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1"
+          }
+        },
+        "web3-providers-ws": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.1.tgz",
+          "integrity": "sha512-oqsQXzu+ejJACVHy864WwIyw+oB21nw/pI65/sD95Zi98+/HQzFfNcIFneF1NC4bVF3VNX4YHTNq2I2o97LAiA==",
+          "requires": {
+            "underscore": "1.9.1",
+            "web3-core-helpers": "1.2.1",
+            "websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+          }
+        },
+        "web3-shh": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.1.tgz",
+          "integrity": "sha512-/3Cl04nza5kuFn25bV3FJWa0s3Vafr5BlT933h26xovQ6HIIz61LmvNQlvX1AhFL+SNJOTcQmK1SM59vcyC8bA==",
+          "requires": {
+            "web3-core": "1.2.1",
+            "web3-core-method": "1.2.1",
+            "web3-core-subscriptions": "1.2.1",
+            "web3-net": "1.2.1"
+          }
         }
       }
     },
@@ -978,9 +1518,9 @@
       }
     },
     "@truffle/codec": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.5.4.tgz",
-      "integrity": "sha512-G438MHpODGORbqdf5qufLXFc+8tfNpET2QMdOwu0ahwEfbR2J3KGhoOHdua+NZRVO4uNP1x2XK6inuqIwFNI1A==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.5.5.tgz",
+      "integrity": "sha512-RcpUnsWn3UoaBYL7jXOsJOLPnMzojQZEMW1LK7Wnc8ZNGWxL9fG6C3qcHepBogNyXy0Fhr1S4NaxgXTAFVRXHg==",
       "requires": {
         "big.js": "^5.2.2",
         "bn.js": "^4.11.8",
@@ -1047,73 +1587,6 @@
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
               "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
             }
-          }
-        }
-      }
-    },
-    "@truffle/codec": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.5.1.tgz",
-      "integrity": "sha512-zvXM/tRqOKldlm0iiYdkdyMpLMtwcWZnj2NfTWlBeL8yvgpHhNDxALNuHv9tiaRktckl/is80WiT9LL6mDn75Q==",
-      "requires": {
-        "big.js": "^5.2.2",
-        "bn.js": "^4.11.8",
-        "debug": "^4.1.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.partition": "^4.6.0",
-        "lodash.sum": "^4.0.2",
-        "semver": "^6.3.0",
-        "source-map-support": "^0.5.16",
-        "utf8": "^3.0.0",
-        "web3-utils": "1.2.1"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "eth-lib": {
-          "version": "0.2.7",
-          "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
-          "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
-          "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "xhr-request-promise": "^0.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        },
-        "underscore": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
-          "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
-        },
-        "web3-utils": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
-          "integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
-          "requires": {
-            "bn.js": "4.11.8",
-            "eth-lib": "0.2.7",
-            "ethjs-unit": "0.1.6",
-            "number-to-bn": "1.7.0",
-            "randomhex": "0.1.5",
-            "underscore": "1.9.1",
-            "utf8": "3.0.0"
           }
         }
       }
@@ -1966,16 +2439,16 @@
       }
     },
     "@truffle/debug-utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-4.1.4.tgz",
-      "integrity": "sha512-IU9tjr1rem2AwogDPPnH3wACMs3wjVyimqmPzSKX6zCe/XFAh4nUu/qwaigZjr8fP6bNzlwaH9CMLWMWljB7WA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-4.1.6.tgz",
+      "integrity": "sha512-clLZgcz1D2eoD1J2A6Oq7VkdszRTeVRoR9PGWFaSEhcdVjU0UgrbzK5gAuZ/mNQf1q6nKEMvzZCEh3iKZyygAQ==",
       "requires": {
-        "@truffle/codec": "^0.5.4",
+        "@truffle/codec": "^0.5.5",
         "@trufflesuite/chromafi": "^2.1.2",
         "chalk": "^2.4.2",
         "debug": "^4.1.0",
         "highlight.js": "^9.15.8",
-        "highlightjs-solidity": "^1.0.15",
+        "highlightjs-solidity": "^1.0.16",
         "node-dir": "0.1.17"
       },
       "dependencies": {
@@ -2473,9 +2946,9 @@
           }
         },
         "@types/node": {
-          "version": "12.12.42",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.42.tgz",
-          "integrity": "sha512-R/9QdYFLL9dE9l5cWWzWIZByVGFd7lk7JVOJ7KD+E1SJ4gni7XJRLz9QTjyYQiHIqEAgku9VgxdLjMlhhUaAFg=="
+          "version": "12.12.47",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
+          "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A=="
         },
         "eth-lib": {
           "version": "0.2.7",
@@ -2722,9 +3195,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.24",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
-              "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
+              "version": "10.17.26",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+              "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
             },
             "elliptic": {
               "version": "6.3.3",
@@ -3116,11 +3589,6 @@
         "@types/node": "*"
       }
     },
-    "@types/events": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
-    },
     "@types/fs-extra": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-7.0.0.tgz",
@@ -3130,11 +3598,10 @@
       }
     },
     "@types/glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-VgNIkxK+j7Nz5P7jvUZlRvhuPSmsEfS03b0alKcq5V/STUKAa3Plemsn5mrQUO7am6OErJ4rhGEGJbACclrtRA==",
       "requires": {
-        "@types/events": "*",
         "@types/minimatch": "*",
         "@types/node": "*"
       }
@@ -3354,6 +3821,11 @@
         "color-convert": "^1.9.0"
       }
     },
+    "antlr4ts": {
+      "version": "0.5.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/antlr4ts/-/antlr4ts-0.5.0-alpha.3.tgz",
+      "integrity": "sha512-La89tKkGcHFIVuruv4Bm1esc3zLmES2NOTEwwNS1pudz+zx/0FNqQeUu9p48i9/QHKPVqjN87LB+q3buTg7oDQ=="
+    },
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -3440,6 +3912,17 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+    },
+    "array.prototype.map": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.2.tgz",
+      "integrity": "sha512-Az3OYxgsa1g7xDYp86l0nnN4bcmuEITGe1rbdEBVkrqkzMgDcbdQ2R7r41pNzti+4NMces3H8gMmuioZUilLgw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "is-string": "^1.0.4"
+      }
     },
     "asn1": {
       "version": "0.2.4",
@@ -4002,18 +4485,18 @@
       }
     },
     "chokidar": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
+      "integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
+        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.2.0"
+        "readdirp": "~3.3.0"
       },
       "dependencies": {
         "normalize-path": {
@@ -4065,10 +4548,35 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "circular": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/circular/-/circular-1.0.5.tgz",
+      "integrity": "sha1-fad6+Yu96c5LWzWM1Va13e0tMUk="
+    },
     "class-is": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/class-is/-/class-is-1.1.0.tgz",
       "integrity": "sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw=="
+    },
+    "cli-color": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-1.4.0.tgz",
+      "integrity": "sha512-xu6RvQqqrWEo6MPR1eixqGPywhYBHRs653F9jfXB2Hx4jdM/3WxiNE1vppRmxtMIfl16SFYTpYlrnqH/HsK/2w==",
+      "requires": {
+        "ansi-regex": "^2.1.1",
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "memoizee": "^0.4.14",
+        "timers-ext": "^0.1.5"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        }
+      }
     },
     "cli-cursor": {
       "version": "3.1.0",
@@ -4078,10 +4586,32 @@
         "restore-cursor": "^3.1.0"
       }
     },
+    "cli-logger": {
+      "version": "0.5.40",
+      "resolved": "https://registry.npmjs.org/cli-logger/-/cli-logger-0.5.40.tgz",
+      "integrity": "sha1-CX8OEbByx8aYomxH9YiinCC0iws=",
+      "requires": {
+        "circular": "^1.0.5",
+        "cli-util": "~1.1.27"
+      }
+    },
+    "cli-regexp": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cli-regexp/-/cli-regexp-0.1.2.tgz",
+      "integrity": "sha1-a82TsJ+y7RAl0woRVdWZeVSlNRI="
+    },
     "cli-spinners": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.3.0.tgz",
       "integrity": "sha512-Xs2Hf2nzrvJMFKimOR7YR0QwZ8fc0u98kdtwN1eNAZzNQgH3vK2pXzff6GJtKh7S5hoJ87ECiAiZFS2fb5Ii2w=="
+    },
+    "cli-util": {
+      "version": "1.1.27",
+      "resolved": "https://registry.npmjs.org/cli-util/-/cli-util-1.1.27.tgz",
+      "integrity": "sha1-QtaeNqBAoyH8nPhRwVE8rcUJMFQ=",
+      "requires": {
+        "cli-regexp": "~0.1.0"
+      }
     },
     "cli-width": {
       "version": "2.2.1",
@@ -4623,6 +5153,11 @@
         "object-keys": "^1.0.12"
       }
     },
+    "delay": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.3.0.tgz",
+      "integrity": "sha512-Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA=="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -4973,6 +5508,32 @@
         "string.prototype.trimright": "^2.1.1"
       }
     },
+    "es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
+    },
+    "es-get-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
+      "integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
+      "requires": {
+        "es-abstract": "^1.17.4",
+        "has-symbols": "^1.0.1",
+        "is-arguments": "^1.0.4",
+        "is-map": "^2.0.1",
+        "is-set": "^2.0.1",
+        "is-string": "^1.0.5",
+        "isarray": "^2.0.5"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+        }
+      }
+    },
     "es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
@@ -5010,6 +5571,17 @@
       "requires": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-html": {
@@ -5572,6 +6144,15 @@
         "strip-hex-prefix": "1.0.0"
       }
     },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
     "eventemitter3": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
@@ -5779,9 +6360,9 @@
       "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-glob": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
-      "integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -21241,9 +21822,9 @@
       "integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg=="
     },
     "highlightjs-solidity": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/highlightjs-solidity/-/highlightjs-solidity-1.0.15.tgz",
-      "integrity": "sha512-ZC9mcL7vLOD8aqy3+EVaX9FgQceSVYFMzrmjsMI0l1f9yCEcbcFqEf+G+DtmLcathOmMnNP5l+UdnrZ4zJJ8rQ=="
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/highlightjs-solidity/-/highlightjs-solidity-1.0.16.tgz",
+      "integrity": "sha512-uxdj3Qn4cBoY1zNIe8BSiwvw14G9Nq99HWEqPqFSu/rBCFaz84C+N/FChpPcUjd6q+cVsXOdyafCIAx5LHhBEQ=="
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -21352,16 +21933,6 @@
         "strip-indent": "^2.0.0"
       }
     },
-    "husky": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
-      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
-      "requires": {
-        "is-ci": "^1.0.10",
-        "normalize-path": "^1.0.0",
-        "strip-indent": "^2.0.0"
-      }
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -21396,9 +21967,9 @@
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "ignore": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.6.tgz",
-      "integrity": "sha512-cgXgkypZBcCnOgSihyeqbo6gjIaIyDqPQB7Ra4vhE9m6kigdGoQDMHjviFhRZo3IMlRy6yElosoviMs5YxZXUA=="
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
     },
     "immediate": {
       "version": "3.2.3",
@@ -21491,9 +22062,9 @@
       }
     },
     "interpret": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
-      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA=="
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -21504,6 +22075,11 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -21587,6 +22163,11 @@
       "resolved": "https://registry.npmjs.org/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz",
       "integrity": "sha1-fY035q135dEnFIkTxXPggtd39VQ="
     },
+    "is-map": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
+      "integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw=="
+    },
     "is-natural-number": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
@@ -21622,6 +22203,11 @@
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
+    "is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+    },
     "is-regex": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -21635,10 +22221,20 @@
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
       "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
     },
+    "is-set": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
+      "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA=="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-string": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
     },
     "is-symbol": {
       "version": "1.0.3",
@@ -21712,6 +22308,20 @@
       "requires": {
         "has-to-string-tag-x": "^1.2.0",
         "is-object": "^1.0.1"
+      }
+    },
+    "iterate-iterator": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
+      "integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw=="
+    },
+    "iterate-value": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
+      "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
+      "requires": {
+        "es-get-iterator": "^1.0.2",
+        "iterate-iterator": "^1.0.1"
       }
     },
     "js-sha3": {
@@ -22318,6 +22928,14 @@
         "yallist": "^3.0.2"
       }
     },
+    "lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "requires": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "ltgt": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
@@ -22391,6 +23009,21 @@
         }
       }
     },
+    "memoizee": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.14.tgz",
+      "integrity": "sha512-/SWFvWegAIYAO4NQMpcX+gcra0yEZu4OntmUdrBaWrJncxOqAziGFlHxc7yjKVK2uu3lpPW27P27wkR82wA8mg==",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.45",
+        "es6-weak-map": "^2.0.2",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.1",
+        "lru-queue": "0.1",
+        "next-tick": "1",
+        "timers-ext": "^0.1.5"
+      }
+    },
     "memorystream": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
@@ -22410,9 +23043,9 @@
       }
     },
     "merge2": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
     "merkle-patricia-tree": {
       "version": "2.3.2",
@@ -22521,9 +23154,9 @@
       }
     },
     "min-indent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
-      "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -22579,41 +23212,37 @@
       }
     },
     "mocha": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
-      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.0.1.tgz",
+      "integrity": "sha512-vefaXfdYI8+Yo8nPZQQi0QO2o+5q9UIMX1jZ1XMmK3+4+CQjc7+B0hPdUeglXiTlr8IHMVRo63IhO9Mzt6fxOg==",
       "requires": {
-        "ansi-colors": "3.2.3",
+        "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.3.0",
+        "chokidar": "3.3.1",
         "debug": "3.2.6",
-        "diff": "3.5.0",
+        "diff": "4.0.2",
         "escape-string-regexp": "1.0.5",
-        "find-up": "3.0.0",
-        "glob": "7.1.3",
+        "find-up": "4.1.0",
+        "glob": "7.1.6",
         "growl": "1.10.5",
         "he": "1.2.0",
         "js-yaml": "3.13.1",
         "log-symbols": "3.0.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.5",
-        "ms": "2.1.1",
-        "node-environment-flags": "1.0.6",
+        "ms": "2.1.2",
         "object.assign": "4.1.0",
-        "strip-json-comments": "2.0.1",
-        "supports-color": "6.0.0",
-        "which": "1.3.1",
+        "promise.allsettled": "1.0.2",
+        "serialize-javascript": "3.0.0",
+        "strip-json-comments": "3.0.1",
+        "supports-color": "7.1.0",
+        "which": "2.0.2",
         "wide-align": "1.1.3",
+        "workerpool": "6.0.0",
         "yargs": "13.3.2",
         "yargs-parser": "13.1.2",
         "yargs-unparser": "1.6.0"
       },
       "dependencies": {
-        "ansi-colors": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-          "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw=="
-        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -22622,38 +23251,83 @@
             "ms": "^2.1.1"
           }
         },
-        "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
           }
         },
-        "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
           "requires": {
-            "minimist": "^1.2.5"
+            "p-locate": "^4.1.0"
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "strip-json-comments": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+          "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw=="
         },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -22874,6 +23548,49 @@
       "resolved": "https://registry.npmjs.org/mythxjs/-/mythxjs-1.3.12.tgz",
       "integrity": "sha512-PN3dQeiH57OIteo1dDaRJl9Y3l6vlIcHfhLO2yEVFgXH22bHcEzXU3uyp89Ie9M7Ice/D8TiPMMTOZ/HY42RRg==",
       "requires": {
+        "base-x": "^3.0.8",
+        "buffer": "^5.5.0"
+      }
+    },
+    "multicodec": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-0.5.7.tgz",
+      "integrity": "sha512-PscoRxm3f+88fAtELwUnZxGDkduE2HD9Q6GHUOywQLjOGT/HAdhjLDYNZ1e7VR0s0TP0EwZ16LNUTFpoBGivOA==",
+      "requires": {
+        "varint": "^5.0.0"
+      }
+    },
+    "multihashes": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-0.4.19.tgz",
+      "integrity": "sha512-ej74GAfA20imjj00RO5h34aY3pGUFyzn9FJZFWwdeUHlHTkKmv90FrNpvYT4jYf1XXCy5O/5EjVnxTaESgOM6A==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "multibase": "^0.7.0",
+        "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "multibase": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.7.0.tgz",
+          "integrity": "sha512-TW8q03O0f6PNFTQDvh3xxH03c8CjGaaYrjkl9UQPG6rz53TQzzxJVCIWVjzcbN/Q5Y53Zd0IBQBMVktVgNx4Fg==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        }
+      }
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+    },
+    "mythxjs": {
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/mythxjs/-/mythxjs-1.3.12.tgz",
+      "integrity": "sha512-PN3dQeiH57OIteo1dDaRJl9Y3l6vlIcHfhLO2yEVFgXH22bHcEzXU3uyp89Ie9M7Ice/D8TiPMMTOZ/HY42RRg==",
+      "requires": {
         "axios": "^0.19.0",
         "chai-as-promised": "^7.1.1",
         "jsonwebtoken": "^8.5.1"
@@ -22938,15 +23655,6 @@
       "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
       "requires": {
         "lodash.toarray": "^4.4.0"
-      }
-    },
-    "node-environment-flags": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
-      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
-      "requires": {
-        "object.getownpropertydescriptors": "^2.0.3",
-        "semver": "^5.7.0"
       }
     },
     "node-fetch": {
@@ -23539,6 +24247,18 @@
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
       "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g=="
     },
+    "promise.allsettled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
+      "integrity": "sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==",
+      "requires": {
+        "array.prototype.map": "^1.0.1",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1",
+        "iterate-value": "^1.0.0"
+      }
+    },
     "protobufjs": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.9.0.tgz",
@@ -23636,6 +24356,11 @@
         "object-assign": "^4.1.0",
         "strict-uri-encode": "^1.0.0"
       }
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "randomatic": {
       "version": "3.1.1",
@@ -23775,11 +24500,11 @@
       }
     },
     "readdirp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
+      "integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
       "requires": {
-        "picomatch": "^2.0.4"
+        "picomatch": "^2.0.7"
       }
     },
     "rechoir": {
@@ -23951,6 +24676,33 @@
             "web3-net": "1.2.8",
             "web3-shh": "1.2.8",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-bzz": {
@@ -23982,6 +24734,31 @@
               "version": "12.12.42",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.42.tgz",
               "integrity": "sha512-R/9QdYFLL9dE9l5cWWzWIZByVGFd7lk7JVOJ7KD+E1SJ4gni7XJRLz9QTjyYQiHIqEAgku9VgxdLjMlhhUaAFg=="
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
             }
           }
         },
@@ -23993,6 +24770,33 @@
             "underscore": "1.9.1",
             "web3-eth-iban": "1.2.8",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-core-method": {
@@ -24005,6 +24809,33 @@
             "web3-core-promievent": "1.2.8",
             "web3-core-subscriptions": "1.2.8",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-core-promievent": {
@@ -24055,6 +24886,33 @@
             "web3-eth-personal": "1.2.8",
             "web3-net": "1.2.8",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-eth-abi": {
@@ -24065,6 +24923,33 @@
             "@ethersproject/abi": "5.0.0-beta.153",
             "underscore": "1.9.1",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-eth-accounts": {
@@ -24094,6 +24979,33 @@
                 "elliptic": "^6.4.0",
                 "xhr-request-promise": "^0.1.2"
               }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              },
+              "dependencies": {
+                "eth-lib": {
+                  "version": "0.2.7",
+                  "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                  "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                  "requires": {
+                    "bn.js": "^4.11.6",
+                    "elliptic": "^6.4.0",
+                    "xhr-request-promise": "^0.1.2"
+                  }
+                }
+              }
             }
           }
         },
@@ -24111,6 +25023,33 @@
             "web3-core-subscriptions": "1.2.8",
             "web3-eth-abi": "1.2.8",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-eth-ens": {
@@ -24127,6 +25066,33 @@
             "web3-eth-abi": "1.2.8",
             "web3-eth-contract": "1.2.8",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-eth-iban": {
@@ -24136,6 +25102,33 @@
           "requires": {
             "bn.js": "4.11.8",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-eth-personal": {
@@ -24155,6 +25148,31 @@
               "version": "12.12.42",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.42.tgz",
               "integrity": "sha512-R/9QdYFLL9dE9l5cWWzWIZByVGFd7lk7JVOJ7KD+E1SJ4gni7XJRLz9QTjyYQiHIqEAgku9VgxdLjMlhhUaAFg=="
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
             }
           }
         },
@@ -24166,6 +25184,33 @@
             "web3-core": "1.2.8",
             "web3-core-method": "1.2.8",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-providers-http": {
@@ -24639,6 +25684,11 @@
         }
       }
     },
+    "serialize-javascript": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.0.0.tgz",
+      "integrity": "sha512-skZcHYw2vEX4bw90nAr2iTTsz6x2SrHEnfxgKYmZlvJYBEZrvbKtobJWlQ20zczKb3bsHHXXTYt48zBA7ni9cw=="
+    },
     "serve-static": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
@@ -24790,10 +25840,59 @@
         "is-fullwidth-code-point": "^2.0.0"
       }
     },
+    "sol-merger": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sol-merger/-/sol-merger-3.0.1.tgz",
+      "integrity": "sha512-zVYm51Kym+lruM5DLuhRjYeiQ014TXM3iWpVluR6oVjTEFKF/Q/LmrcQZK7JF/ceK9zpYpcU1YJPdZRvEsvV5w==",
+      "requires": {
+        "antlr4ts": "^0.5.0-alpha.3",
+        "cli-color": "^1.4.0",
+        "commander": "^4.0.1",
+        "debug": "^4.1.1",
+        "fs-extra": "^8.0.1",
+        "glob": "^7.1.2",
+        "strip-json-comments": "^3.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "strip-json-comments": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+          "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w=="
+        }
+      }
+    },
     "solc": {
-      "version": "0.6.8",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.6.8.tgz",
-      "integrity": "sha512-7URBAisWVjO7dwWNpEkQ5dpRSpSF4Wm0aD5EB82D5BQKh+q7jhOxhgkG4K5gax/geM0kPZUAxnaLcgl2ZXBgMQ==",
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.6.10.tgz",
+      "integrity": "sha512-+oHwIvNjg3bxXvL9yua/Z4ZFEdkCkgRSh7aIGGb+mf/gzoA8PRKiKGYDsjMaj0CJLH1BTBOUpNFeYhhnUFfjRg==",
       "requires": {
         "command-exists": "^1.2.8",
         "commander": "3.0.2",
@@ -24879,9 +25978,9 @@
       }
     },
     "solidity-coverage": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.7.5.tgz",
-      "integrity": "sha512-UaNwVhK7I1ULYK3qDTATs7Hz0YKhJnE+rm5aU9ufUBowOImB2dWYXox2l/tMbSkHfTMWwHE/6TNqn0/ec0rwOw==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.7.7.tgz",
+      "integrity": "sha512-hD043l+Hy8cNMqrI6k5wZNEc7ceVJIWaWztE8D7u8QqbaObZldpknDJPRXHnRGniI5t6HeOQ+8F4ifiNCn2BeA==",
       "requires": {
         "@solidity-parser/parser": "^0.6.0",
         "@truffle/provider": "^0.1.17",
@@ -24904,9 +26003,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.42",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.42.tgz",
-          "integrity": "sha512-R/9QdYFLL9dE9l5cWWzWIZByVGFd7lk7JVOJ7KD+E1SJ4gni7XJRLz9QTjyYQiHIqEAgku9VgxdLjMlhhUaAFg=="
+          "version": "12.12.47",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.47.tgz",
+          "integrity": "sha512-yzBInQFhdY8kaZmqoL2+3U5dSTMrKaYcb561VU+lDzAYvqt+2lojvBEy+hmpSNuXnPTx7m9+04CzWYOUqWME2A=="
         },
         "bn.js": {
           "version": "4.11.8",
@@ -24941,9 +26040,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.24",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
-              "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
+              "version": "10.17.26",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+              "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
             },
             "elliptic": {
               "version": "6.3.3",
@@ -25015,9 +26114,9 @@
           },
           "dependencies": {
             "@types/node": {
-              "version": "10.17.24",
-              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.24.tgz",
-              "integrity": "sha512-5SCfvCxV74kzR3uWgTYiGxrd69TbT1I6+cMx1A5kEly/IVveJBimtAMlXiEyVFn5DvUFewQWxOOiJhlxeQwxgA=="
+              "version": "10.17.26",
+              "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.26.tgz",
+              "integrity": "sha512-myMwkO2Cr82kirHY8uknNRHEVtn0wV3DTQfkrjx17jmkstDRZ24gNUdl8AHXVyVclTYI/bNjgTPTAWvWLqXqkw=="
             }
           }
         },
@@ -25729,6 +26828,15 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
+    "timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "requires": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
+    },
     "tiny-async-pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.1.0.tgz",
@@ -25792,9 +26900,9 @@
       }
     },
     "truffle": {
-      "version": "5.1.27",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.1.27.tgz",
-      "integrity": "sha512-um/mxQ0y8ZQ5+iDApqfvV4+yZX7UOyWlbzYmtFvJRkkB4PRk0xghV9ssDBC1zlXFy/OmSTUSzApQXA2WA763/Q==",
+      "version": "5.1.30",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-5.1.30.tgz",
+      "integrity": "sha512-wA88Ija0qO3ggzIEFMydg7FfxRqNRbYq1WVmb9Mdvx1D416RojRBotdML7KPH6T5lE6UKK8UeTalDTdG2KKqeQ==",
       "requires": {
         "app-module-path": "^2.2.0",
         "mocha": "5.2.0",
@@ -26261,6 +27369,28 @@
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
               "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
             }
+          }
+        }
+      }
+    },
+    "truffle-plugin-verify": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/truffle-plugin-verify/-/truffle-plugin-verify-0.3.11.tgz",
+      "integrity": "sha512-RN18HcPSuxcdP1oDlRjIu56fEx+Bo1Rf0h+Ra/cI1dQ8rQcdikpdy4r+CHxT/mvUy8vEwS39doB5vWDNvydpPA==",
+      "requires": {
+        "axios": "0.19.2",
+        "cli-logger": "0.5.40",
+        "delay": "4.3.0",
+        "querystring": "0.2.0",
+        "sol-merger": "3.0.1"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.19.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+          "requires": {
+            "follow-redirects": "1.5.10"
           }
         }
       }
@@ -27030,6 +28160,33 @@
             "web3-net": "1.2.8",
             "web3-shh": "1.2.8",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-bzz": {
@@ -27061,6 +28218,31 @@
               "version": "12.12.42",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.42.tgz",
               "integrity": "sha512-R/9QdYFLL9dE9l5cWWzWIZByVGFd7lk7JVOJ7KD+E1SJ4gni7XJRLz9QTjyYQiHIqEAgku9VgxdLjMlhhUaAFg=="
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
             }
           }
         },
@@ -27072,6 +28254,33 @@
             "underscore": "1.9.1",
             "web3-eth-iban": "1.2.8",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-core-method": {
@@ -27084,6 +28293,33 @@
             "web3-core-promievent": "1.2.8",
             "web3-core-subscriptions": "1.2.8",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-core-promievent": {
@@ -27134,6 +28370,33 @@
             "web3-eth-personal": "1.2.8",
             "web3-net": "1.2.8",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-eth-abi": {
@@ -27144,6 +28407,33 @@
             "@ethersproject/abi": "5.0.0-beta.153",
             "underscore": "1.9.1",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-eth-accounts": {
@@ -27173,6 +28463,33 @@
                 "elliptic": "^6.4.0",
                 "xhr-request-promise": "^0.1.2"
               }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              },
+              "dependencies": {
+                "eth-lib": {
+                  "version": "0.2.7",
+                  "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+                  "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+                  "requires": {
+                    "bn.js": "^4.11.6",
+                    "elliptic": "^6.4.0",
+                    "xhr-request-promise": "^0.1.2"
+                  }
+                }
+              }
             }
           }
         },
@@ -27190,6 +28507,33 @@
             "web3-core-subscriptions": "1.2.8",
             "web3-eth-abi": "1.2.8",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-eth-ens": {
@@ -27206,6 +28550,33 @@
             "web3-eth-abi": "1.2.8",
             "web3-eth-contract": "1.2.8",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-eth-iban": {
@@ -27215,6 +28586,33 @@
           "requires": {
             "bn.js": "4.11.8",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-eth-personal": {
@@ -27234,6 +28632,31 @@
               "version": "12.12.42",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.42.tgz",
               "integrity": "sha512-R/9QdYFLL9dE9l5cWWzWIZByVGFd7lk7JVOJ7KD+E1SJ4gni7XJRLz9QTjyYQiHIqEAgku9VgxdLjMlhhUaAFg=="
+            },
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
             }
           }
         },
@@ -27245,6 +28668,33 @@
             "web3-core": "1.2.8",
             "web3-core-method": "1.2.8",
             "web3-utils": "1.2.8"
+          },
+          "dependencies": {
+            "eth-lib": {
+              "version": "0.2.7",
+              "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
+              "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
+              "requires": {
+                "bn.js": "^4.11.6",
+                "elliptic": "^6.4.0",
+                "xhr-request-promise": "^0.1.2"
+              }
+            },
+            "web3-utils": {
+              "version": "1.2.8",
+              "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
+              "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+              "requires": {
+                "bn.js": "4.11.8",
+                "eth-lib": "0.2.7",
+                "ethereum-bloom-filters": "^1.0.6",
+                "ethjs-unit": "0.1.6",
+                "number-to-bn": "1.7.0",
+                "randombytes": "^2.1.0",
+                "underscore": "1.9.1",
+                "utf8": "3.0.0"
+              }
+            }
           }
         },
         "web3-providers-http": {
@@ -28341,9 +29791,9 @@
       }
     },
     "web3-utils": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.8.tgz",
-      "integrity": "sha512-9SIVGFLajwlmo5joC4DGxuy2OeDkRCXVWT8JWcDQ+BayNVHyAWGvn0oGkQ0ys14Un0KK6bjjKoD0xYs4k+FaVw==",
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.9.tgz",
+      "integrity": "sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==",
       "requires": {
         "bn.js": "4.11.8",
         "eth-lib": "0.2.7",
@@ -28453,6 +29903,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
+    "workerpool": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.0.tgz",
+      "integrity": "sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA=="
     },
     "wrap-ansi": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animoca/ethereum-contracts-core_library",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Base dependency for solidity contracts projects",
   "repository": {
     "type": "git",
@@ -11,26 +11,29 @@
     "compile": "./scripts/oz-compile.sh",
     "test": "./scripts/oz-test.sh",
     "coverage": "./scripts/coverage.sh",
-    "migrate": "./scripts/migrate.sh"
+    "verify": "./scripts/verify.sh",
+    "migrate": "./scripts/migrate.sh",
+    "publish": "./scripts/publish.sh"
   },
   "author": "Animoca Brands",
   "license": "MIT",
   "dependencies": {
     "@openzeppelin/cli": "^2.8.2",
-    "@openzeppelin/contracts": "^3.0.1",
+    "@openzeppelin/contracts": "^3.0.2",
     "@openzeppelin/test-environment": "^0.1.4",
-    "@openzeppelin/test-helpers": "^0.5.5",
-    "@truffle/debug-utils": "^4.1.4",
+    "@openzeppelin/test-helpers": "^0.5.6",
+    "@truffle/debug-utils": "^4.1.6",
     "async": "^3.2.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "chai-bignumber": "^3.0.0",
-    "mocha": "^7.2.0",
-    "solc": "^0.6.8",
-    "solidity-coverage": "^0.7.5",
-    "truffle": "^5.1.27",
+    "mocha": "^8.0.1",
+    "solc": "^0.6.10",
+    "solidity-coverage": "^0.7.7",
+    "truffle": "^5.1.30",
+    "truffle-plugin-verify": "^0.3.11",
     "truffle-security": "^1.7.1",
-    "web3-utils": "^1.2.8"
+    "web3-utils": "^1.2.9"
   },
   "devDependencies": {
     "lodash.zip": "^4.2.0"

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-truffle run coverage
+truffle run coverage "$@"

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-truffle migrate --network ganache
+truffle migrate "$@"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+truffle run etherscan "$@"

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+truffle run verify "$@"

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 const constants = require('./constants');
 const interfaces = require('./interfaces/ERC165');
-const shouldSupportInterfaces = require('../test/contracts/introspection/SupportsInterface.behavior');
+const behaviors = require('../test/behaviors');
+const fixtures = require('../test/fixtures');
 
 module.exports = {
     constants,
     interfaces,
-    shouldSupportInterfaces
+    fixtures,
+    behaviors,
 }

--- a/test/behaviors/index.js
+++ b/test/behaviors/index.js
@@ -1,0 +1,7 @@
+const publicRole = require('../contracts/access/PublicRole.behavior');
+const supportsInterface = require('../contracts/introspection/SupportsInterface.behavior');
+
+module.exports = {
+    ...publicRole,
+    ...supportsInterface
+}

--- a/test/contracts/access/PublicRole.behavior.js
+++ b/test/contracts/access/PublicRole.behavior.js
@@ -1,7 +1,7 @@
 const { expectRevert, expectEvent } = require('@openzeppelin/test-helpers');
-const { ZeroAddress } = require('../../../src').constants;
+const { ZeroAddress } = require('./../../../src/constants');
 
-function capitalize (str) {
+function capitalize(str) {
     return str.replace(/\b\w/g, l => l.toUpperCase());
 }
 
@@ -12,157 +12,157 @@ async function expectEventInConstruction(contract, eventName, eventArgs = {}) {
             fromBlock: 0,
             toBlock: 'latest'
         });
-        const pastEvent = pastEvents.find((item) => {
-            return item.transactionHash === contract.transactionHash;
+    const pastEvent = pastEvents.find((item) => {
+        return item.transactionHash === contract.transactionHash;
+    });
+
+    pastEvent.should.not.be.undefined;
+
+    const eventArgKeys = Object.keys(eventArgs);
+
+    eventArgKeys.every((key) => {
+        return eventArgs[key] === pastEvent.returnValues[key];
+    }).should.be.true;
+}
+
+// Tests that a role complies with the standard role interface, that is:
+//  * an onlyRole modifier
+//  * an isRole function
+//  * an addRole function, accessible to role havers
+//  * a renounceRole function
+//  * roleAdded and roleRemoved events
+// Both the modifier and an additional internal remove function are tested through a mock contract that exposes them.
+// This mock contract should be stored in this.contract.
+//
+// @param authorized an account that has the role
+// @param otherAuthorized another account that also has the role
+// @param other an account that doesn't have the role, passed inside an array for ergonomics
+// @param rolename a string with the name of the role
+// @param manager undefined for regular roles, or a manager account for managed roles. In these, only the manager
+// account can create and remove new role bearers.
+function shouldBehaveLikePublicRole(authorized, otherAuthorized, [other], rolename, manager) {
+    rolename = capitalize(rolename);
+
+    describe('should behave like public role', function () {
+        beforeEach('check preconditions', async function () {
+            (await this.contract[`is${rolename}`](authorized)).should.equal(true);
+            (await this.contract[`is${rolename}`](otherAuthorized)).should.equal(true);
+            (await this.contract[`is${rolename}`](other)).should.equal(false);
         });
 
-        pastEvent.should.not.be.undefined;
-
-        const eventArgKeys = Object.keys(eventArgs);
-
-        eventArgKeys.every((key) => {
-            return eventArgs[key] === pastEvent.returnValues[key];
-        }).should.be.true;
-    }
-
-    // Tests that a role complies with the standard role interface, that is:
-    //  * an onlyRole modifier
-    //  * an isRole function
-    //  * an addRole function, accessible to role havers
-    //  * a renounceRole function
-    //  * roleAdded and roleRemoved events
-    // Both the modifier and an additional internal remove function are tested through a mock contract that exposes them.
-    // This mock contract should be stored in this.contract.
-    //
-    // @param authorized an account that has the role
-    // @param otherAuthorized another account that also has the role
-    // @param other an account that doesn't have the role, passed inside an array for ergonomics
-    // @param rolename a string with the name of the role
-    // @param manager undefined for regular roles, or a manager account for managed roles. In these, only the manager
-    // account can create and remove new role bearers.
-    function shouldBehaveLikePublicRole (authorized, otherAuthorized, [other], rolename, manager) {
-        rolename = capitalize(rolename);
-
-        describe('should behave like public role', function () {
-            beforeEach('check preconditions', async function () {
-                (await this.contract[`is${rolename}`](authorized)).should.equal(true);
-                (await this.contract[`is${rolename}`](otherAuthorized)).should.equal(true);
-                (await this.contract[`is${rolename}`](other)).should.equal(false);
-            });
-
-            if (manager === undefined) { // Managed roles are only assigned by the manager, and none are set at construction
-                it('emits events during construction', async function () {
-                    // await expectEvent.inConstruction(this.contract, `${rolename}Added`, {
-                    //   account: authorized,
-                    // });
-                    await expectEventInConstruction(this.contract, `${rolename}Added`, {
-                        account: authorized,
-                    });
+        if (manager === undefined) { // Managed roles are only assigned by the manager, and none are set at construction
+            it('emits events during construction', async function () {
+                // await expectEvent.inConstruction(this.contract, `${rolename}Added`, {
+                //   account: authorized,
+                // });
+                await expectEventInConstruction(this.contract, `${rolename}Added`, {
+                    account: authorized,
                 });
-            }
-
-            it('reverts when querying roles for the null account', async function () {
-                await expectRevert.unspecified(this.contract[`is${rolename}`](ZeroAddress));
             });
+        }
 
-            describe('access control', function () {
-                context('from authorized account', function () {
-                    const from = authorized;
+        it('reverts when querying roles for the null account', async function () {
+            await expectRevert.unspecified(this.contract[`is${rolename}`](ZeroAddress));
+        });
 
-                    it('allows access', async function () {
-                        if (!this.contract[`only${rolename}Mock`]) return;
+        describe('access control', function () {
+            context('from authorized account', function () {
+                const from = authorized;
 
-                        await this.contract[`only${rolename}Mock`]({ from });
-                    });
-                });
+                it('allows access', async function () {
+                    if (!this.contract[`only${rolename}Mock`]) return;
 
-                context('from unauthorized account', function () {
-                    const from = other;
-
-                    it('reverts', async function () {
-                        if (!this.contract[`only${rolename}Mock`]) return;
-
-                        await expectRevert.unspecified(this.contract[`only${rolename}Mock`]({ from }));
-                    });
+                    await this.contract[`only${rolename}Mock`]({ from });
                 });
             });
 
-            describe('add', function () {
-                const from = manager === undefined ? authorized : manager;
+            context('from unauthorized account', function () {
+                const from = other;
 
-                context(`from ${manager ? 'the manager' : 'a role-haver'} account`, function () {
-                    it('adds role to a new account', async function () {
-                        await this.contract[`add${rolename}`](other, { from });
-                        (await this.contract[`is${rolename}`](other)).should.equal(true);
-                    });
+                it('reverts', async function () {
+                    if (!this.contract[`only${rolename}Mock`]) return;
 
-                    it(`emits a ${rolename}Added event`, async function () {
-                        const receipt = await this.contract[`add${rolename}`](other, { from });
-                        expectEvent(receipt, `${rolename}Added`, { account: other });
-                    });
-
-                    it('reverts when adding role to an already assigned account', async function () {
-                        await expectRevert.unspecified(this.contract[`add${rolename}`](authorized, { from }));
-                    });
-
-                    it('reverts when adding role to the null account', async function () {
-                        await expectRevert.unspecified(this.contract[`add${rolename}`](ZeroAddress, { from }));
-                    });
+                    await expectRevert.unspecified(this.contract[`only${rolename}Mock`]({ from }));
                 });
             });
+        });
 
-            describe('remove', function () {
-                // Non-managed roles have no restrictions on the mocked '_remove' function (exposed via 'remove').
-                const from = manager || other;
+        describe('add', function () {
+            const from = manager === undefined ? authorized : manager;
 
-                context(`from ${manager ? 'the manager' : 'any'} account`, function () {
-                    it('removes role from an already assigned account', async function () {
-                        if (!this.contract[`remove${rolename}`]) return;
+            context(`from ${manager ? 'the manager' : 'a role-haver'} account`, function () {
+                it('adds role to a new account', async function () {
+                    await this.contract[`add${rolename}`](other, { from });
+                    (await this.contract[`is${rolename}`](other)).should.equal(true);
+                });
 
-                        await this.contract[`remove${rolename}`](authorized, { from });
-                        (await this.contract[`is${rolename}`](authorized)).should.equal(false);
-                        (await this.contract[`is${rolename}`](otherAuthorized)).should.equal(true);
-                    });
+                it(`emits a ${rolename}Added event`, async function () {
+                    const receipt = await this.contract[`add${rolename}`](other, { from });
+                    expectEvent(receipt, `${rolename}Added`, { account: other });
+                });
 
-                    it(`emits a ${rolename}Removed event`, async function () {
-                        if (!this.contract[`remove${rolename}`]) return;
+                it('reverts when adding role to an already assigned account', async function () {
+                    await expectRevert.unspecified(this.contract[`add${rolename}`](authorized, { from }));
+                });
 
-                        const receipt = await this.contract[`remove${rolename}`](authorized, { from });
-                        expectEvent(receipt, `${rolename}Removed`, { account: authorized });
-                    });
-
-                    it('reverts when removing from an unassigned account', async function () {
-                        if (!this.contract[`remove${rolename}`]) return;
-
-                        await expectRevert.unspecified(this.contract[`remove${rolename}`](other, { from }));
-                    });
-
-                    it('reverts when removing role from the null account', async function () {
-                        if (!this.contract[`remove${rolename}`]) return;
-
-                        await expectRevert.unspecified(this.contract[`remove${rolename}`](ZeroAddress, { from }));
-                    });
+                it('reverts when adding role to the null account', async function () {
+                    await expectRevert.unspecified(this.contract[`add${rolename}`](ZeroAddress, { from }));
                 });
             });
+        });
 
-            describe('renouncing roles', function () {
-                it('renounces an assigned role', async function () {
-                    await this.contract[`renounce${rolename}`]({ from: authorized });
+        describe('remove', function () {
+            // Non-managed roles have no restrictions on the mocked '_remove' function (exposed via 'remove').
+            const from = manager || other;
+
+            context(`from ${manager ? 'the manager' : 'any'} account`, function () {
+                it('removes role from an already assigned account', async function () {
+                    if (!this.contract[`remove${rolename}`]) return;
+
+                    await this.contract[`remove${rolename}`](authorized, { from });
                     (await this.contract[`is${rolename}`](authorized)).should.equal(false);
+                    (await this.contract[`is${rolename}`](otherAuthorized)).should.equal(true);
                 });
 
                 it(`emits a ${rolename}Removed event`, async function () {
-                    const receipt = await this.contract[`renounce${rolename}`]({ from: authorized });
+                    if (!this.contract[`remove${rolename}`]) return;
+
+                    const receipt = await this.contract[`remove${rolename}`](authorized, { from });
                     expectEvent(receipt, `${rolename}Removed`, { account: authorized });
                 });
 
-                it('reverts when renouncing unassigned role', async function () {
-                    await expectRevert.unspecified(this.contract[`renounce${rolename}`]({ from: other }));
+                it('reverts when removing from an unassigned account', async function () {
+                    if (!this.contract[`remove${rolename}`]) return;
+
+                    await expectRevert.unspecified(this.contract[`remove${rolename}`](other, { from }));
+                });
+
+                it('reverts when removing role from the null account', async function () {
+                    if (!this.contract[`remove${rolename}`]) return;
+
+                    await expectRevert.unspecified(this.contract[`remove${rolename}`](ZeroAddress, { from }));
                 });
             });
         });
-    }
 
-    module.exports = {
-        shouldBehaveLikePublicRole,
-    };
+        describe('renouncing roles', function () {
+            it('renounces an assigned role', async function () {
+                await this.contract[`renounce${rolename}`]({ from: authorized });
+                (await this.contract[`is${rolename}`](authorized)).should.equal(false);
+            });
+
+            it(`emits a ${rolename}Removed event`, async function () {
+                const receipt = await this.contract[`renounce${rolename}`]({ from: authorized });
+                expectEvent(receipt, `${rolename}Removed`, { account: authorized });
+            });
+
+            it('reverts when renouncing unassigned role', async function () {
+                await expectRevert.unspecified(this.contract[`renounce${rolename}`]({ from: other }));
+            });
+        });
+    });
+}
+
+module.exports = {
+    shouldBehaveLikePublicRole,
+};

--- a/test/contracts/introspection/SupportsInterface.behavior.js
+++ b/test/contracts/introspection/SupportsInterface.behavior.js
@@ -2,7 +2,7 @@ function shouldSupportInterfaces(interfaces) {
 
     describe('ERC165 supportsInterface(bytes4)', function () {
         beforeEach(function () {
-            this.contract = this.mock || this.token;
+            this.contract = this.contract || this.mock || this.token;
         });
 
         for (const interface of interfaces) {
@@ -20,4 +20,6 @@ function shouldSupportInterfaces(interfaces) {
     });
 }
 
-module.exports = shouldSupportInterfaces;
+module.exports = {
+    shouldSupportInterfaces
+};

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,0 +1,5 @@
+const weiPrecision = require('./weiPrecision');
+
+module.exports = {
+    ...weiPrecision
+}

--- a/test/fixtures/weiPrecision.js
+++ b/test/fixtures/weiPrecision.js
@@ -1,0 +1,37 @@
+const { fromWei } = require('web3-utils');
+const { BN } = require('@openzeppelin/test-helpers');
+
+/**
+ * Validates that `actual` equals `expected` with a precision of at least `decimalPrecision` ETH decimals.
+ * @param {BN} actual the actual value, in WEI.
+ * @param {BN} expected the expected value, in WEI.
+ * @param {Number} decimals the number ETH decimals. The default value is 4 which is a precision of 10^4 = 0.0001 ETH
+ */
+function shouldBeEqualWithETHDecimalPrecision(actual, expected, decimals = 4) {
+    const exponent = new BN(18 /* ETH-precision divisor */ - decimals);
+    const tolerance = new BN(10).pow(exponent);
+    const delta = actual.sub(expected).abs();
+    delta.should.be.bignumber.lte(tolerance,
+        `${fromWei(actual)} differs from expected ${fromWei(expected)} (tolerance ${fromWei(tolerance)} ETH)`
+    );
+}
+
+/**
+ * Validates that `actual` equals `expected` with a difference not exceeding 1/`N`-th of the expected value.
+ * @param {BN} actual the actual value, in WEI.
+ * @param {BN} expected the expected value, in WEI.
+ * @param {Number} divisor `N` in the above formula. The default value is 1,000,000.
+ */
+function shouldBeEqualWithProportionalPrecision(actual, expected, divisor = 1000000) {
+    const divsPrecision = new BN(10).pow(new BN(15)); // used to preserve floating point division precision
+    const tolerance = expected.mul(divsPrecision).div(new BN(divisor)).div(divsPrecision);
+    const delta = actual.sub(expected).abs();
+    delta.should.be.bignumber.lte(tolerance,
+        `${fromWei(actual)} differs from expected ${fromWei(expected)} (proportional tolerance 1/${divisor}th)`
+    );
+}
+
+module.exports = {
+    shouldBeEqualWithETHDecimalPrecision,
+    shouldBeEqualWithProportionalPrecision
+}

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,7 +1,7 @@
 require('chai').should();
 
 module.exports = {
-    plugins: ['truffle-security', 'solidity-coverage'],
+    plugins: ['truffle-security', 'solidity-coverage', 'truffle-plugin-verify'],
 
     networks: {
         ganache: {
@@ -10,6 +10,7 @@ module.exports = {
             port: 7545,
         },
     },
+
     compilers: {
         solc: {
             version: '0.6.8',
@@ -21,4 +22,9 @@ module.exports = {
             }
         }
     }
+
+    // Necessary to use the command `npm run publish`
+    // api_keys: {
+    //     etherscan: 'etherscanAPIKey'
+    // },
 };


### PR DESCRIPTION
### Breaking changes
 * Contracts compiler version fixed at solidity 0.6.8.
 * `shouldSupportInterfaces` is no more exposed at module level but inside the `behaviors` object instead.
 * Updated mocha dependency from version 7 to version 8.

### New features
 * `behaviors` and `fixtures` object are now exposed at module level.
 * Added fixtures for wei-based BN comparison with precision tolerance.
 * Added a `verify` and a `publish` scripts. 

### Improvements
 * `shouldSupportInterfaces` now works on `this.contract` object.